### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.4.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/actions/list_vms.yaml
+++ b/actions/list_vms.yaml
@@ -1,6 +1,6 @@
 ---
 name: list_vms
-runner_type: run-python
+runner_type: python-script
 description: List available VMs.
 enabled: true
 entry_point: list_vms.py

--- a/actions/parse.yaml
+++ b/actions/parse.yaml
@@ -1,6 +1,6 @@
 ---
 name: parse
-runner_type: run-python
+runner_type: python-script
 description: Parse XML string and return JSON object.
 enabled: true
 entry_point: parse_xml.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - some
   - search
   - terms
-version : "0.3.0"
+version : 0.4.0
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.