### PR TITLE
Add gitignore to minimize noise for st2 development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+*.py[cod]
+*.sqlite
+*.swp
+*.log
+*/requirements.txt
+.stamp*
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+.venv
+eggs
+parts
+#bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib64
+virtualenv
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+cover
+coverage*.xml
+.tox
+nosetests.xml
+
+# Mr Developer
+.idea
+.DS_Store
+._*
+.vscode
+*.sublime-project
+*.sublime-workspace
+
+# Editor Saves
+*~
+\#*\#


### PR DESCRIPTION
When making tests for st2 repo, pyc files are generated in this pack and marked as untracked files in st2. Add a gitignore here to minimize noise for st2 development.